### PR TITLE
Slightly lighten input backgrounds so they don't appear inactive

### DIFF
--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -100,9 +100,9 @@
   --c-input-border-color-hover: color(var(--gray08));
   --c-input-border-color-focused: color(var(--blue10));
   --c-input-color: color(var(--c-text-description));
-  --c-input-bg-color: color(var(--white12));
-  --c-input-bg-color-hover: color(var(--white11));
-  --c-input-bg-color-focused: color(var(--white10));
+  --c-input-bg-color: color(var(--white11));
+  --c-input-bg-color-hover: color(var(--white10));
+  --c-input-bg-color-focused: color(var(--white09));
 
   /* Shadow */
   --shadow:


### PR DESCRIPTION
This has been bothering me forever, and was emphasized further when building the new website. Affect Input, Textarea, Checkbox, etc.

### Before
![image](https://user-images.githubusercontent.com/3267/101643950-a6efa180-3a02-11eb-9c1f-0154e597b02f.png)

### After
![image](https://user-images.githubusercontent.com/3267/101644014-b7078100-3a02-11eb-81be-c2a1f1b0386e.png)
